### PR TITLE
Fixing ElasticIndex type mapping and add_items , search methods

### DIFF
--- a/vecsim/__init__.py
+++ b/vecsim/__init__.py
@@ -1,3 +1,3 @@
-__version__="0.0.37"
+__version__="0.0.4"
 from .similarity_helpers import RedisIndex,SciKitIndex,FaissIndex,ElasticIndex
 from .similarity_helpers import available_engines


### PR DESCRIPTION
Fixes for the `ElasticIndex` Class,

- `mappings`:
  Following [ElasticSearch v8+ Mapping Types](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html)
  Fixing types and field names, was raising an error resulting to failure with creation of the index

- `add_items` method:
  According to [ElasticSearch v8+ Removal of types](https://www.elastic.co/guide/en/elasticsearch/reference/8.5/removal-of-types.html) and [ElasticSearch v8+ Bulk API document](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html) no need for `__type`,
Raised an error executing the method

- `search` method:
  Following [ElasticSearch v8+ kNN Search](https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html),
  Fixed the sent query,
  Raised an error for incorrect query

