### PR TITLE
fixed initialization when index exsits

### DIFF
--- a/vecsim/similarity_helpers.py
+++ b/vecsim/similarity_helpers.py
@@ -203,7 +203,11 @@ class RedisIndex(BaseIndex):
                 index_exists = False
             if index_exists:
                 self.redis.ft(self.index_name).dropindex(delete_documents=True)
-        self.init_hnsw()
+            self.init_hnsw()
+        try:
+            self.redis.ft(self.index_name).info()
+        except:
+            raise Exception("Index not found, please initialize the index by setting overwrite to True")
         # applicable only for user events
         self.user_keys=[]
     


### PR DESCRIPTION
@urigoren 
Currently when you try initialise the Index with overwrite=False the init_hnsw() function still runs.
Redis throw an error when index is already exists.
I added a check for the existence of the index, raising an informative error if it is not.
Plus I moved the init_hnsw function to run only of overwrite flag is set to True (which is by default).
